### PR TITLE
CKAN-44 & CKAN 211

### DIFF
--- a/ckanext/mxtheme/templates/package/resource_read.html
+++ b/ckanext/mxtheme/templates/package/resource_read.html
@@ -1,6 +1,12 @@
 {% extends "package/base.html" %}
 
 {% set res = c.resource %}
+{% block custom_styles %}
+  super()
+  <style type="text/css">
+    .breadcrumb>li:last-child>a { pointer-events: all !important; }
+  </style>
+{% endblock %}
 
 {% block head_extras -%}
   {{ super() }}

--- a/ckanext/mxtheme/templates/page.html
+++ b/ckanext/mxtheme/templates/page.html
@@ -19,7 +19,7 @@
                  <div class="row" style="margin-top: 100px;">
                    {% block breadcrumb %}
                      {% if self.breadcrumb_content() | trim %}
-                        <div class="col-md-7">
+                        <div class="col-md-7 col-sm-12">
                             <ul class="breadcrumb">
                               {% snippet 'snippets/home_breadcrumb_item.html' %}
                               {% block breadcrumb_content %}{% endblock %}
@@ -33,7 +33,7 @@
                         #}
                      {% endif %}
                     {% endblock %}
-                     <div class="col-md-5">
+                     <div class="col-md-5 col-sm-12">
                         <ul class="submenu">
                             <li><a href="/busca/dataset">Todos los datos</a></li>
                             <li><a href="/busca/organization">Instituciones</a></li>


### PR DESCRIPTION
- Los breadcrumbs salen en varias lineas separadas cuando son muy largos
- en la vista de recurso, la parte del breadcrumb del dataset debe linkear al dataset