### PR TITLE
CKAN 143: Nombres que no son acronimos salen con guiones medios.

### DIFF
--- a/ckanext/mxtheme/fanstatic/mx.css
+++ b/ckanext/mxtheme/fanstatic/mx.css
@@ -7047,10 +7047,7 @@ h1:after {
 .dataset-item h3,
 .dataset-item .dependency {
   margin-top: 10px;
-}
-
-.dependency {
-  text-transform: uppercase;
+  width: fit-content;
 }
 
 .dataset-item h4 {

--- a/ckanext/mxtheme/plugin.py
+++ b/ckanext/mxtheme/plugin.py
@@ -4,6 +4,8 @@ import i18n
 import logging
 import datetime
 import urlparse
+##### STRING
+import string
 
 import ckan.exceptions
 import ckan.plugins as plugins
@@ -176,6 +178,13 @@ def get_grafica_base_url():
     url_grafica_base = os.environ.get("GRAFICA_BASE_URL", "https://cdn.datos.gob.mx/assets/css/main.css")
     return url_grafica_base
 
+def get_clear_organization_name(name):
+    if (string.find(name, '-') > 0):
+        name = name.replace('-',' ');
+        name = name.title()
+    else:
+        name = name.upper()
+    return name
 
 def sorted_extras_dgm(extras):
     sorted_list = sorted_extras(extras)
@@ -231,5 +240,6 @@ class MxthemePlugin(plugins.SingletonPlugin):
             'slugify_text': slugify_name,
             'get_adela_endpoint': get_adela_endpoint,
             'sorted_extras_dgm': sorted_extras_dgm,
-            'get_grafica_base_url': get_grafica_base_url
+            'get_grafica_base_url': get_grafica_base_url,
+            'get_clear_organization_name': get_clear_organization_name
         }

--- a/ckanext/mxtheme/templates/snippets/package_item.html
+++ b/ckanext/mxtheme/templates/snippets/package_item.html
@@ -56,7 +56,7 @@ Example:
         {% if package.organization %}
           <div class="dependency">
             <strong>
-              <a href="{{h.url_for(package.organization.type ~ '_read', action='read', id=package.organization.name)}}">{{package.organization.name}}
+              <a href="{{h.url_for(package.organization.type ~ '_read', action='read', id=package.organization.name)}}">{{ h.get_clear_organization_name(package.organization.name) }}
               </a>
             </strong>
             <!-- {% if package.organization.description != '' and package.organization.description != None %}


### PR DESCRIPTION
Se quitan los guiones medios cuando no es un acronimo.
Se hace el uppercase dependiendo de los casos:
Nombre con acronimo: todo en mayusculas
Nombre sin acronimos: Las iniciales en mayusculas